### PR TITLE
Removed hard coding of the urlOptions 

### DIFF
--- a/Utils/UrlNormalizer.cs
+++ b/Utils/UrlNormalizer.cs
@@ -43,8 +43,6 @@ namespace Sitecore.SharedSource.RedirectManager.Utils
         startItem = Context.Site.StartItem.ToLower();
         virtualFolder = GetVirtualVolder();
       }
-
-      urlOptions = new UrlOptions { LanguageEmbedding = LanguageEmbedding.Never, AddAspxExtension = true };
     }
 
     /// <summary>
@@ -177,7 +175,7 @@ namespace Sitecore.SharedSource.RedirectManager.Utils
 
       using (new SiteContextSwitcher(SiteContext.GetSite("website")))
       {
-        return LinkManager.GetItemUrl(item, urlOptions).ToLower();
+        return LinkManager.GetItemUrl(item).ToLower();
       }
     }
 


### PR DESCRIPTION
We meant to send this pull request ages ago sorry! Details of this change are below:

Removed hard coding of the urlOptions so that the configuration for the Link Manager through config is used. This allows such settings as AddAspxExtension to be set to false and not be added to a redirect.
